### PR TITLE
Fix silent failure when copying multiple tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,15 +1,48 @@
-chrome.commands.onCommand.addListener(cmd => {
-    if (cmd === 'copy-tab-url') {
-        copyUrl({ format: 'plaintext' })
-    } else if (cmd === 'copy-tab-url-md') {
-        copyUrl({ format: 'markdown' })
-    }
-})
-
 /**
  * @typedef {Object} CopyOptions
  * @property {'plaintext' | 'markdown'} format - The format in which to copy the URL(s).
 */
+
+chrome.commands.onCommand.addListener(async cmd => {
+    if (cmd === 'copy-tab-url') {
+        await copyUrl({ format: 'plaintext' })
+    } else if (cmd === 'copy-tab-url-md') {
+        await copyUrl({ format: 'markdown' })
+    }
+})
+
+/** A global promise to avoid concurrency issues */
+let creating;
+/**
+ * @param {string} path Path to the offscreen document
+ * @returns 
+ */
+async function setupOffscreenDocument(path) {
+    // Check all windows controlled by the service worker to see if one
+    // of them is the offscreen document with the given path
+    const offscreenUrl = chrome.runtime.getURL(path)
+    const existingContexts = await chrome.runtime.getContexts({
+        contextTypes: ['OFFSCREEN_DOCUMENT'],
+        documentUrls: [offscreenUrl]
+    })
+    if (existingContexts.length > 0) {
+        console.warn('offscreen document already exists')
+        return;
+    }
+
+    // Create the offscreen document
+    if (creating) {
+        await creating
+    } else {
+        creating = chrome.offscreen.createDocument({
+            url: path,
+            reasons: [chrome.offscreen.Reason.CLIPBOARD],
+            justification: 'write url text to the clipboard',
+        });
+        await creating
+        creating = null
+    }
+}
 
 /**
  * Copies the URLs of all highlighted tabs in the current window to the clipboard,
@@ -17,16 +50,19 @@ chrome.commands.onCommand.addListener(cmd => {
  * @param {Object} options - Options for formatting the URLs.
  * @param {string} options.format - The format to use when formatting each URL.
  */
-function copyUrl(options) {
-    chrome.tabs.query({ highlighted: true, currentWindow: true }, tabs => {
-        if (!tabs || tabs.length === 0) { return }
-        const urls = tabs.map(tab => formatUrl(tab, options.format)).join('\n')
-        chrome.scripting.executeScript({
-            target: { tabId: tabs[0].id },
-            func: (text) => navigator.clipboard.writeText(text),
-            args: [urls]
-        })
-    })
+async function copyUrl(options) {
+    const tabs = await chrome.tabs.query({ highlighted: true, currentWindow: true })
+    if (!tabs || tabs.length === 0) { return }
+    const urls = tabs.map(tab => formatUrl(tab, options.format)).join('\n')
+
+    await setupOffscreenDocument('offscreen.html')
+
+    const response = await chrome.runtime.sendMessage({ action: 'copy', target: 'offscreen-doc', text: urls })
+    if (response.success) {
+        console.log("Copied to clipboard!")
+    } else {
+        console.error("Clipboard copy failed", response.error)
+    }
 }
 
 /**
@@ -47,3 +83,6 @@ function formatUrl(tab, format) {
     }
 }
 
+// Note: Once extension service workers can use the Clipboard API,
+// Note: replace the offscreen document based implementation with something like this.
+// navigator.clipboard.writeText(value)

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
     "manifest_version": 3,
     "name": "Copy Tab URL",
-    "version": "1.0",
+    "version": "1.1",
     "description": "Copy the URL of the current (or selected) tabs.",
     "permissions": [
         "tabs",
         "scripting",
+        "offscreen",
         "clipboardWrite"
     ],
     "host_permissions": [

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+    <textarea id="text"></textarea>
+    <script src="offscreen.js"></script>
+</body>
+
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,49 @@
+// We use a <textarea> element for two main reasons:
+//  1. preserve the formatting of multiline text,
+//  2. select the node's content using this element's `.select()` method.
+const textarea = document.getElementById('text');
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    // Return early if this message isn't meant for the offscreen document.
+    if (message.target !== 'offscreen-doc') {
+        return;
+    }
+
+    // Dispatch message to the appropriate handler
+    if (message.action === "copy") {
+        handleClipboardWrite(message.text, sendResponse)
+    } else {
+        const err = `Unexpected message action received: ${message.action}`
+        sendResponse({ success: false, error: err })
+    }
+});
+
+
+// Use the offscreen document's `document` interface to write a new value to the
+// system clipboard.
+//
+// The `navigator.clipboard` API requires that the window be focused, but offscreen documents cannot be
+// focused. As such, we have to fall back to `document.execCommand()`.
+//
+// @see https://github.com/GoogleChrome/chrome-extensions-samples/blob/main/functional-samples/cookbook.offscreen-clipboard-write/offscreen.js
+async function handleClipboardWrite(data, sendResponse) {
+    try {
+        // Error if we received the wrong kind of data.
+        if (typeof data !== 'string') {
+            return sendResponse({ success: false, error: `Value provided must be a 'string', git '${typeof data}' ` })
+        }
+
+        // `document.execCommand('copy')` works against the user's selection in a web
+        // page. As such, we must insert the string we want to copy to the web page
+        // and to select that content in the page before calling `execCommand()`.
+        textarea.value = data
+        textarea.select()
+        document.execCommand('copy')
+        sendResponse({ success: true })
+    } catch (e) {
+        sendResponse({ success: false, error: e.toString() })
+    } finally {
+        // Close the offscreen document when we are finally done
+        window.close()
+    }
+}

--- a/offscreen.js
+++ b/offscreen.js
@@ -30,7 +30,7 @@ async function handleClipboardWrite(data, sendResponse) {
     try {
         // Error if we received the wrong kind of data.
         if (typeof data !== 'string') {
-            return sendResponse({ success: false, error: `Value provided must be a 'string', git '${typeof data}' ` })
+            return sendResponse({ success: false, error: `Value provided must be a 'string', got '${typeof data}'` })
         }
 
         // `document.execCommand('copy')` works against the user's selection in a web


### PR DESCRIPTION
Enhancements ensure that copying multiple selected tabs works reliably by implementing an offscreen document for clipboard operations. This addresses the silent failure issue when executing the copy action for multiple tabs.

Fixes #2