### PR TITLE
Add popup for Copy Tab URL extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
         "service_worker": "background.js"
     },
     "action": {
-        "default_title": "Copy Tab URL"
+        "default_title": "Copy Tab URL",
+        "default_popup": "popup.html"
     },
     "commands": {
         "copy-tab-url": {

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Copy Tab URL</title>
+</head>
+
+<style>
+    body,
+    html {
+        width: 480px;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        padding-bottom: 0.125rem;
+    }
+
+    h1 {
+        font-size: 1.25rem;
+    }
+
+    kbd {
+        background-color: #eee;
+        padding: 0.5ch 0.75ch;
+        margin-inline: 0.5ch;
+        border-radius: 0.5ch;
+        box-shadow: 0px 2px 2px 2px #ddd
+    }
+</style>
+
+<body>
+    <h1>Copy Tab Url</h1>
+    <p>
+        Use the keyboard shortcut (default: <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>) to instantly copy the current
+        tab's url to the clipboard. If multiple tabs have been selected, the shortcut will copy the urls of all selected
+        tabs.
+    </p>
+    <p>
+        Alternatively, you can copy the urls in markdown format. (default: <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd>)
+    </p>
+</body>
+
+</html>


### PR DESCRIPTION
Introduce a popup HTML interface for the Copy Tab URL extension, providing users with instructions and keyboard shortcuts for copying URLs.