### PR TITLE
Add notifications for clipboard copy success and failure

### DIFF
--- a/background.js
+++ b/background.js
@@ -62,7 +62,7 @@ async function copyUrl(options) {
         chrome.notifications.create({
             type: 'basic',
             title: 'Copy Tab URL',
-            message: `Copied ${tabs.length} url(s) to clipboard`,
+            message: `Copied ${tabs.length} URL(s) to clipboard`,
             iconUrl: 'assets/icon48.png'
         })
     } else {
@@ -70,7 +70,7 @@ async function copyUrl(options) {
         chrome.notifications.create({
             type: 'basic',
             title: 'Copy Tab URL',
-            message: "Failed to copy tab urls",
+            message: "Failed to copy tab URLs",
             iconUrl: 'assets/icon48.png'
         })
     }

--- a/background.js
+++ b/background.js
@@ -59,9 +59,20 @@ async function copyUrl(options) {
 
     const response = await chrome.runtime.sendMessage({ action: 'copy', target: 'offscreen-doc', text: urls })
     if (response.success) {
-        console.log("Copied to clipboard!")
+        chrome.notifications.create({
+            type: 'basic',
+            title: 'Copy Tab URL',
+            message: `Copied ${tabs.length} url(s) to clipboard`,
+            iconUrl: 'assets/icon48.png'
+        })
     } else {
         console.error("Clipboard copy failed", response.error)
+        chrome.notifications.create({
+            type: 'basic',
+            title: 'Copy Tab URL',
+            message: "Failed to copy tab urls",
+            iconUrl: 'assets/icon48.png'
+        })
     }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,6 @@
         "32": "assets/icon32.png",
         "48": "assets/icon48.png",
         "64": "assets/icon64.png",
-        "12": "assets/icon128.png"
+        "128": "assets/icon128.png"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,13 @@
 {
     "manifest_version": 3,
     "name": "Copy Tab URL",
-    "version": "1.1",
+    "version": "0.2",
     "description": "Copy the URL of the current (or selected) tabs.",
     "permissions": [
         "tabs",
         "scripting",
         "offscreen",
+        "notifications",
         "clipboardWrite"
     ],
     "host_permissions": [


### PR DESCRIPTION
Notifications now inform users of the success or failure of clipboard copy actions, enhancing user feedback. Additionally, the manifest version has been updated to include the notifications permission.